### PR TITLE
Add configurable values for requests timeout and wait duration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ reports/
 /src/
 \#*\#
 *.egg-info
+.idea/

--- a/xqueue_watcher/client.py
+++ b/xqueue_watcher/client.py
@@ -5,13 +5,20 @@ import requests
 from requests.auth import HTTPBasicAuth
 import threading
 import multiprocessing
+from manager import MANAGER_CONFIG_DEFAULTS
 
 log = logging.getLogger(__name__)
 
 
 class XQueueClient(object):
-    def __init__(self, queue_name, xqueue_server='http://localhost:18040', xqueue_auth=('user', 'pass'),
-                 http_basic_auth=None):
+    def __init__(self,
+                 queue_name,
+                 xqueue_server='http://localhost:18040',
+                 xqueue_auth=('user', 'pass'),
+                 http_basic_auth=MANAGER_CONFIG_DEFAULTS['HTTP_BASIC_AUTH'],
+                 requests_timeout=MANAGER_CONFIG_DEFAULTS['REQUESTS_TIMEOUT'],
+                 poll_interval=MANAGER_CONFIG_DEFAULTS['POLL_INTERVAL'],
+                 login_poll_interval=MANAGER_CONFIG_DEFAULTS['LOGIN_POLL_INTERVAL']):
         super(XQueueClient, self).__init__()
         self.session = requests.session()
         self.xqueue_server = xqueue_server
@@ -19,6 +26,9 @@ class XQueueClient(object):
         self.handlers = []
         self.daemon = True
         self.username, self.password = xqueue_auth
+        self.requests_timeout = requests_timeout
+        self.poll_interval = poll_interval
+        self.login_poll_interval = login_poll_interval
 
         if http_basic_auth is not None:
             self.http_basic_auth = HTTPBasicAuth(*http_basic_auth)
@@ -58,7 +68,7 @@ class XQueueClient(object):
 
         return return_code, content
 
-    def _request(self, method, uri, timeout=0.5, **kwargs):
+    def _request(self, method, uri, **kwargs):
         url = self.xqueue_server + uri
         r = None
         while not r:
@@ -67,12 +77,12 @@ class XQueueClient(object):
                     method,
                     url,
                     auth=self.http_basic_auth,
-                    timeout=timeout,
+                    timeout=self.requests_timeout,
                     allow_redirects=False,
                     **kwargs
                 )
             except requests.exceptions.ConnectionError as e:
-                log.error('Could not connect to server at %s in timeout=%r', url, timeout)
+                log.error('Could not connect to server at %s in timeout=%r', url, self.requests_timeout)
                 return (False, e.message)
             if r.status_code == 200:
                 return self._parse_response(r)
@@ -163,7 +173,7 @@ class XQueueClient(object):
             num_tries = 1
             while self.running:
                 num_tries += 1
-                time.sleep(5)
+                time.sleep(self.login_poll_interval)
                 if not self._login():
                     log.error("Still could not log in to %s (%s:%s) tries: %d",
                         self.queue_name,
@@ -174,7 +184,7 @@ class XQueueClient(object):
                     break
         while self.running:
             if not self.process_one():
-                time.sleep(1)
+                time.sleep(self.poll_interval)
         return True
 
 

--- a/xqueue_watcher/manager.py
+++ b/xqueue_watcher/manager.py
@@ -19,6 +19,25 @@ CODEJAIL_LANGUAGES = {
     'python2': codejail.languages.python2,
     'python3': codejail.languages.python3,
 }
+MANAGER_CONFIG_DEFAULTS = {
+    'HTTP_BASIC_AUTH': None,
+    'POLL_TIME': 10,
+    'REQUESTS_TIMEOUT': 1,
+    'POLL_INTERVAL': 1,
+    'LOGIN_POLL_INTERVAL': 5,
+}
+
+
+def get_manager_config_values(app_config_path):
+    if not app_config_path.exists():
+        return MANAGER_CONFIG_DEFAULTS.copy()
+    with open(app_config_path) as config:
+        config_tokens = json.load(config)
+        return {
+            config_key: config_tokens.get(config_key, default_config_value)
+            for config_key, default_config_value in MANAGER_CONFIG_DEFAULTS.items()
+        }
+
 
 class Manager(object):
     """
@@ -26,23 +45,27 @@ class Manager(object):
     """
     def __init__(self):
         self.clients = []
-        self.poll_time = 10
         self.log = logging
-        self.http_basic_auth = None
+        self.manager_config = MANAGER_CONFIG_DEFAULTS.copy()
 
-    def client_from_config(self, queue_name, config):
+    def client_from_config(self, queue_name, watcher_config):
         """
         Return an XQueueClient from the configuration object.
         """
         from . import client
 
-        klass = getattr(client, config.get('CLASS', 'XQueueClientThread'))
-        watcher = klass(queue_name,
-                        xqueue_server=config.get('SERVER', 'http://localhost:18040'),
-                        xqueue_auth=config.get('AUTH', (None, None)),
-                        http_basic_auth=self.http_basic_auth)
+        klass = getattr(client, watcher_config.get('CLASS', 'XQueueClientThread'))
+        watcher = klass(
+            queue_name,
+            xqueue_server=watcher_config.get('SERVER', 'http://localhost:18040'),
+            xqueue_auth=watcher_config.get('AUTH', (None, None)),
+            http_basic_auth=self.manager_config['HTTP_BASIC_AUTH'],
+            requests_timeout=self.manager_config['REQUESTS_TIMEOUT'],
+            poll_interval=self.manager_config['POLL_INTERVAL'],
+            login_poll_interval=self.manager_config['LOGIN_POLL_INTERVAL'],
+        )
 
-        for handler_config in config.get('HANDLERS', []):
+        for handler_config in watcher_config.get('HANDLERS', []):
             handler_name = handler_config['HANDLER']
             mod_name, classname = handler_name.rsplit('.', 1)
             module = importlib.import_module(mod_name)
@@ -86,16 +109,10 @@ class Manager(object):
             logging.basicConfig(level="DEBUG")
         self.log = logging.getLogger('xqueue_watcher.manager')
 
-        app_config = directory / 'xqwatcher.json'
-
-        if app_config.exists():
-            with open(app_config) as config:
-                config_tokens = json.load(config)
-                self.http_basic_auth = config_tokens.get('HTTP_BASIC_AUTH',None)
-                self.poll_time = config_tokens.get("POLL_TIME",10)
+        app_config_path = directory / 'xqwatcher.json'
+        self.manager_config = get_manager_config_values(app_config_path)
 
         confd = directory / 'conf.d'
-
         for watcher in confd.files('*.json'):
             with open(watcher) as queue_config:
                 self.configure(json.load(queue_config))
@@ -149,7 +166,7 @@ class Manager(object):
                                    client.queue_name)
                     self.shutdown()
                 try:
-                    time.sleep(self.poll_time)
+                    time.sleep(self.manager_config['POLL_TIME'])
                 except KeyboardInterrupt:  # pragma: no cover
                     self.shutdown()
 


### PR DESCRIPTION
This PR allows us to configure values for HTTP request timeout and wait duration (i.e.: the 'beat' of the requests to the `/xqueue/get_submission` endpoint).