### PR TITLE
Added a short-circuit option for xqueue submissions

### DIFF
--- a/xqueue_watcher/jailedgrader.py
+++ b/xqueue_watcher/jailedgrader.py
@@ -93,6 +93,12 @@ class JailedGrader(Grader):
             'score': 0,
         }
 
+        if grader_config.get('skip_grader', False):
+            results['correct'] = True
+            results['score'] = 1
+            self.log.debug('Skipping the grader.')
+            return results
+
         self._enable_i18n(grader_config.get("lang", LANGUAGE))
 
         answer_path = path(grader_path).dirname() / 'answer.py'


### PR DESCRIPTION
Partially fixes https://github.com/mitodl/salt-ops/issues/531

replaces mitodl/graders-mit-600x#5

Added an option to pass `skip_grader` in the grader_config settings for a problem in order to allow for capturing a student submission but not execute their code.