### PR TITLE
fix: remove python2 -style string concatenation

### DIFF
--- a/grader_support/gradelib.py
+++ b/grader_support/gradelib.py
@@ -241,7 +241,6 @@ def _tokens(code):
     code = code.rstrip() + "\n"
     if isinstance(code, six.text_type):
         code = code.encode('utf8')
-    code = "# coding: utf8\n" + code
     toks = tokenize.generate_tokens(six.BytesIO(code).readline)
     return toks
 


### PR DESCRIPTION
fixes #9 

As pointed out by @cfrontin you can't concatenate a string and a bytearray. 

Since the submission has already been converted to utf-8, it shouldn't be necessary to add an encoding declaration, so this just remove the line. 

### how to test 

Deploy this change to a test grader instance and call it from https://staging.mitx.mit.edu/courses/course-v1:MITx+6.S082r_1+2021_Spring/courseware/21071a2fc9dd4a869904905215a8f971/4a59984ddd8a43998b852c56e1385a82/1?activate_block_id=block-v1%3AMITx%2B6.S082r_1%2B2021_Spring%2Btype%40vertical%2Bblock%409bbba7d9f5d84640a21f2c97b62c27f4

