### PR TITLE
Fix bug when using codejail limits in xqueue-watcher

### DIFF
--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -67,7 +67,8 @@ class ManagerTests(unittest.TestCase):
                 "VMEM": 1024
             }
         }
-        self.m.enable_codejail(config)
+        codejail_return = self.m.enable_codejail(config)
+        self.assertEqual(codejail_return, config["name"])
         self.assertTrue(codejail.jail_code.is_configured("python"))
         self.m.enable_codejail({
             "name": "other-python",

--- a/xqueue_watcher/manager.py
+++ b/xqueue_watcher/manager.py
@@ -120,8 +120,8 @@ class Manager(object):
         user = codejail_config.get('user', getpass.getuser())
         jail_code.configure(name, bin_path, user=user)
         limits = codejail_config.get("limits", {})
-        for name, value in limits.items():
-            jail_code.set_limit(name, value)
+        for limit_name, value in limits.items():
+            jail_code.set_limit(limit_name, value)
         self.log.info("configured codejail -> %s %s %s", name, bin_path, user)
         return name
 


### PR DESCRIPTION
When the `limits` object is set in the codejail configuration block it causes the command used for launching a watcher process to be invalid. This is because there was a variable name used in a for loop that shadowed a variable from an outer scope that is then returned from the `enable_codejail` method that is used as an argument for the execution.