### PR TITLE
Md/issue 2326

### DIFF
--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -1,3 +1,4 @@
+from re import A
 import unittest
 from path import Path
 import json
@@ -40,6 +41,17 @@ class ManagerTests(unittest.TestCase):
                         'HANDLER': 'urllib.urlencode'
                     }
                 ]
+            },
+            'test3': {
+                'AUTH': ('test', 'test'),
+                'CONNECTIONS': 2,
+                'NAME_OVERRIDE': "test4",
+                'SERVER': 'http://test4',
+                'HANDLERS': [
+                    {
+                        'HANDLER': 'tests.test_grader.MockGrader',
+                    }
+                ]
             }
         }
 
@@ -51,10 +63,13 @@ class ManagerTests(unittest.TestCase):
 
     def test_configuration(self):
         self.m.configure(self.config)
-        self.assertEqual(len(self.m.clients), 3)
+        self.assertEqual(len(self.m.clients), 5)
         for c in self.m.clients:
+            self.assertNotEqual(c.queue_name, "test3")
             if c.queue_name == 'test2':
                 self.assertEqual(c.xqueue_server, 'http://test2')
+            if c.queue_name == "test4":
+                self.assertEqual(c.xqueue_server, "http://test4")
 
     @unittest.skipUnless(HAS_CODEJAIL, "Codejail not installed")
     def test_codejail_config(self):

--- a/xqueue_watcher/manager.py
+++ b/xqueue_watcher/manager.py
@@ -32,7 +32,7 @@ class Manager:
 
         klass = getattr(client, watcher_config.get('CLASS', 'XQueueClientThread'))
         watcher = klass(
-            queue_name,
+            queue_name=watcher_config.get('NAME_OVERRIDE', None) or queue_name,
             xqueue_server=watcher_config.get('SERVER', 'http://localhost:18040'),
             xqueue_auth=watcher_config.get('AUTH', (None, None)),
             http_basic_auth=self.manager_config['HTTP_BASIC_AUTH'],


### PR DESCRIPTION
Added a watcher configuration option to override the name of the queue to allow us to pull from multiple xqueue instances that have queues with the same name.


For example:

```json
{
  "Watcher-MITx-6.0001r": {
    "AUTH": [
      "xqwatcher",
      "REDACTED"
    ],
    "CONNECTIONS": 5,
    "HANDLERS": [
      {
        "CODEJAIL": {
          "bin_path": "/home/xqwatcher/xqwatcher/grader_venvs/mit-600x/bin/python",
          "lang": "python3",
          "name": "mit-600x",
          "user": "xqwatcher"
        },
        "HANDLER": "xqueue_watcher.jailedgrader.JailedGrader",
        "KWARGS": {
          "grader_root": "../xqwatcher/graders/mit-600x-Watcher-MITx-6.0001r/graders/python3graders/"
        }
      }
    ],
    "NAME_OVERRIDE": "Watcher-MITx-6.0001r",
    "SERVER": "http://xqueue.service.mitx-qa.consul:8040"
  },
  "Watcher-MITx-staging-6.0001r": {
    "AUTH": [
      "xqwatcher",
      "REDACTED"
    ],
    "CONNECTIONS": 5,
    "HANDLERS": [
      {
        "CODEJAIL": {
          "bin_path": "/home/xqwatcher/xqwatcher/grader_venvs/mit-600x/bin/python",
          "lang": "python3",
          "name": "mit-600x",
          "user": "xqwatcher"
        },
        "HANDLER": "xqueue_watcher.jailedgrader.JailedGrader",
        "KWARGS": {
          "grader_root": "../xqwatcher/graders/mit-600x-Watcher-MITx-6.0001r/graders/python3graders/"
        }
      }
    ],
    "NAME_OVERRIDE": "Watcher-MITx-6.0001r",
    "SERVER": "http://xqueue.service.mitx-staging-qa.consul:8040"
  },

```


Note how both elements of the root dict have different names, however `NAME_OVERRIDE` is the same for both configurations. One `SERVER` directive points to the staging environment and the other points to the normal environment. Both configurations will pull from the queue named `Watcher-MITx-6.0001r` for each environment. Previously, the configuration for the staging environment would have pulled from a queue named `Watcher-MITx-staging-6.0001r` which does not exist.