### PR TITLE
Fix state leak between staff-answer and submission grading passes

### DIFF
--- a/docs/course-teams.md
+++ b/docs/course-teams.md
@@ -364,6 +364,33 @@ If your grader image has dependencies beyond the standard library, or you want t
 exactly the environment that runs in production, build and run the grader container
 locally.
 
+**Fast path: `grade-local`.** `grader_support/tools/grade-local` is a small
+[cyclopts](https://cyclopts.readthedocs.io/) CLI that wraps everything below --
+locating your `grade_*.py`, defaulting the submission to the grader's own
+`answer.py`, building the image on request, and bind-mounting your grader directory
+so edits take effect without a rebuild. Copy it into your own repo (e.g. `bin/grade-local`)
+and run it from your repo root:
+
+```bash
+pip install cyclopts   # or add as a dev dependency
+
+# Build once (or pass --build to grade-local to build automatically):
+docker build --build-arg GRADER_BASE_IMAGE=mitodl/xqueue-watcher-grader-base:latest \
+    -t my-course:local .
+
+bin/grade-local unit-2/exercise-3/grader.py
+bin/grade-local unit-2/exercise-3/grader.py path/to/submission.py
+bin/grade-local unit-2/exercise-3/grader.py --debug   # GRADER_DEBUG=1 trace
+```
+
+It assumes the layout used by every course repo so far: a top-level `graders/`
+directory copied to `/graders/` in the image (`--graders-dir` overrides this), and
+an image tag defaulting to `<repo-dir-name>:local` (`--image` overrides this). See
+`graders-mit-600x` and `graders-mit-686x` for examples of repo-specific copies.
+
+The rest of this section walks through what `grade-local` automates, useful if you
+want to customize the flow or aren't using the standard layout.
+
 **Step 1 — Build the base image** (once per xqueue-watcher checkout):
 
 ```bash

--- a/docs/course-teams.md
+++ b/docs/course-teams.md
@@ -375,7 +375,7 @@ and run it from your repo root:
 pip install cyclopts   # or add as a dev dependency
 
 # Build once (or pass --build to grade-local to build automatically):
-docker build --build-arg GRADER_BASE_IMAGE=mitodl/xqueue-watcher-grader-base:latest \
+docker build --build-arg GRADER_BASE_IMAGE=ghcr.io/openedx/xqueue-watcher-grader-base:latest \
     -t my-course:local .
 
 bin/grade-local unit-2/exercise-3/grader.py

--- a/grader_support/README.md
+++ b/grader_support/README.md
@@ -47,7 +47,7 @@ Course teams create their own image `FROM grader-base` and add their grader scri
 
 ```dockerfile
 # syntax=docker/dockerfile:1
-ARG GRADER_BASE_IMAGE=ghcr.io/mitodl/xqueue-watcher-grader-base:latest
+ARG GRADER_BASE_IMAGE=ghcr.io/openedx/xqueue-watcher-grader-base:latest
 FROM ${GRADER_BASE_IMAGE}
 
 # pip must run as root; the base image ends with USER grader.

--- a/grader_support/entrypoint.py
+++ b/grader_support/entrypoint.py
@@ -123,15 +123,21 @@ def main():
     sys.path.insert(0, "/tmp")
     _dbg(f"sys.path[:4]={sys.path[:4]}")
 
-    from . import run as run_module
+    from . import run as run_module, graderutil
     from .gradelib import EndTest
 
     grader_name = os.path.splitext(os.path.basename(grader_path))[0]
     _dbg(f"grader_name={grader_name!r}")
 
-    # Run the staff answer first to get expected outputs.
+    # Run the staff answer and the student submission as two isolated in-process
+    # imports of the grader module. Without module_isolation(), the second
+    # run_module.run() call below would hit Python's sys.modules cache instead of
+    # re-executing the grader module, silently reusing whatever mutable
+    # module-level state (generators, shared dicts/lists, gradelib.rand snapshotted
+    # via `from gradelib import *`) the first run left behind.
     _dbg("running staff answer")
-    expected_output = run_module.run(grader_name, "answer", seed)
+    with graderutil.module_isolation():
+        expected_output = run_module.run(grader_name, "answer", seed)
     _dbg(f"expected_output grader status={expected_output['grader']['status']!r}"
          f"  submission status={expected_output['submission']['status']!r}"
          f"  exceptions={expected_output['exceptions']}"
@@ -156,7 +162,8 @@ def main():
 
     # Run the student submission.
     _dbg("running student submission")
-    actual_output = run_module.run(grader_name, "submission", seed)
+    with graderutil.module_isolation():
+        actual_output = run_module.run(grader_name, "submission", seed)
     _dbg(f"actual_output grader status={actual_output['grader']['status']!r}"
          f"  submission status={actual_output['submission']['status']!r}"
          f"  exceptions={actual_output['exceptions']}"

--- a/grader_support/entrypoint.py
+++ b/grader_support/entrypoint.py
@@ -61,14 +61,27 @@ def main():
     trans.install(names=None)
     _dbg("gettext installed")
 
+    from . import run as run_module, graderutil
+    from .gradelib import EndTest
+
     # Load the grader module to access test definitions, preprocessors, and
     # input validators.  The grader script is baked into this image.
+    #
+    # This load (and each run_module.run() call below) is wrapped in its own
+    # graderutil.module_isolation() so that any modules it causes to be
+    # imported -- the grader module itself, and any helper modules the grader
+    # script imports -- are purged from sys.modules once we're done with them.
+    # Without this, module-level mutable state in those modules could leak
+    # into the later staff-answer/submission runs even though those runs are
+    # separately isolated from each other, because module_isolation() only
+    # rolls back modules imported *after* it takes its snapshot.
     _dbg(f"loading grader module from {grader_path!r}")
     try:
-        spec = importlib.util.spec_from_file_location("grader_module", grader_path)
-        grader_module_obj = importlib.util.module_from_spec(spec)
-        spec.loader.exec_module(grader_module_obj)
-        grader = grader_module_obj.grader
+        with graderutil.module_isolation():
+            spec = importlib.util.spec_from_file_location("grader_module", grader_path)
+            grader_module_obj = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(grader_module_obj)
+            grader = grader_module_obj.grader
         _dbg(f"grader module loaded OK, tests={len(list(grader.tests()))}")
     except Exception:
         _dbg("EXCEPTION loading grader module:")
@@ -122,9 +135,6 @@ def main():
     sys.path.insert(0, grader_dir)
     sys.path.insert(0, "/tmp")
     _dbg(f"sys.path[:4]={sys.path[:4]}")
-
-    from . import run as run_module, graderutil
-    from .gradelib import EndTest
 
     grader_name = os.path.splitext(os.path.basename(grader_path))[0]
     _dbg(f"grader_name={grader_name!r}")

--- a/grader_support/tools/grade-local
+++ b/grader_support/tools/grade-local
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""Run a course grader against a submission locally, in the real grader container.
+
+Runs the grader through `docker run` against the course repo's own grader image
+(built from its Dockerfile, which extends grader-base -- see
+grader_support/Dockerfile.base and docs/course-teams.md), so local results match
+production exactly: the container's ENTRYPOINT is
+`python -m grader_support.entrypoint`, the same engine xqueue-watcher's
+ContainerGrader invokes for real submissions.
+
+Course teams: copy this file into your own repo's bin/ (e.g. `bin/grade-local`)
+and run it from your repo root. It has no dependency on xqueue-watcher being
+checked out locally -- everything it needs is baked into the Docker image.
+
+The graders directory is bind-mounted read-only over the image's baked-in
+/graders/, so local edits to grade_*.py/answer.py take effect immediately without
+rebuilding the image. Only rebuild when your dependency manifest changes.
+
+Requires: docker, and the `cyclopts` package (pip install cyclopts, or add it as
+a dev dependency).
+"""
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Optional
+
+import cyclopts
+
+REPO_ROOT = Path.cwd()
+DEFAULT_GRADERS_DIR = REPO_ROOT / "graders"
+DEFAULT_IMAGE = f"{REPO_ROOT.name}:local"
+BUILD_CMD = (
+    "docker build --build-arg GRADER_BASE_IMAGE=mitodl/xqueue-watcher-grader-base:latest "
+    f"-t {DEFAULT_IMAGE} ."
+)
+
+app = cyclopts.App(help=__doc__)
+
+
+def _resolve_grader_path(grader: Path) -> Path:
+    grader = grader.resolve()
+    if grader.is_dir():
+        matches = sorted(grader.glob("grade_*.py"))
+        if len(matches) != 1:
+            raise ValueError(
+                f"expected exactly one grade_*.py in {grader}, found {len(matches)}: "
+                f"{[m.name for m in matches]}"
+            )
+        return matches[0]
+    return grader
+
+
+def _container_grader_path(grader_path: Path, graders_dir: Path) -> str:
+    try:
+        rel = grader_path.relative_to(graders_dir)
+    except ValueError:
+        raise SystemExit(f"{grader_path} is not under {graders_dir} (the image only has /graders/).")
+    return f"/graders/{rel.as_posix()}"
+
+
+def _image_exists(image: str) -> bool:
+    return subprocess.run(
+        ["docker", "image", "inspect", image], capture_output=True
+    ).returncode == 0
+
+
+@app.default
+def run(
+    grader: Path,
+    submission: Optional[Path] = None,
+    *,
+    seed: int = 42,
+    lang: str = "en",
+    hide_output: bool = False,
+    debug: bool = False,
+    image: str = DEFAULT_IMAGE,
+    graders_dir: Path = DEFAULT_GRADERS_DIR,
+    build: bool = False,
+    json_output: bool = False,
+) -> None:
+    """Grade a submission against a grader and print the result.
+
+    Parameters
+    ----------
+    grader: Path to a grade_*.py file, or the directory containing one.
+    submission: Path to the student submission. Defaults to the grader's own
+        answer.py, which is a useful smoke test for the grader itself.
+    seed: Random seed shared between the staff answer and the submission run.
+    lang: Language code, passed through as GRADER_LANGUAGE.
+    hide_output: Suppress per-test expected/actual output, matching the
+        HIDE_OUTPUT env var read by grader_support.entrypoint.
+    debug: Enable GRADER_DEBUG=1 and print the entrypoint's stderr trace.
+    image: Docker image tag to run. Defaults to "<repo-dir-name>:local". Build it
+        first (see BUILD_CMD) or pass --build.
+    graders_dir: Host directory bind-mounted read-only to /graders in the
+        container. Defaults to ./graders, matching the COPY in a typical course
+        Dockerfile (see docs/course-teams.md).
+    build: Build the image first if it's missing.
+    json_output: Print the raw result dict as JSON instead of a formatted report.
+    """
+    grader_path = _resolve_grader_path(grader)
+    graders_dir = graders_dir.resolve()
+    submission_path = (submission or grader_path.parent / "answer.py").resolve()
+    container_grader_path = _container_grader_path(grader_path, graders_dir)
+
+    if not _image_exists(image):
+        if build:
+            subprocess.run(["docker", "build", "-t", image, "."], cwd=REPO_ROOT, check=True)
+        else:
+            raise SystemExit(
+                f"Docker image {image!r} not found. Build it first:\n\n  {BUILD_CMD}\n\n"
+                f"or re-run with --build to build it automatically."
+            )
+
+    submission_code = submission_path.read_text(encoding="utf-8")
+
+    docker_cmd = [
+        "docker", "run", "--rm",
+        "-e", f"SUBMISSION_CODE={submission_code}",
+        "-e", f"GRADER_LANGUAGE={lang}",
+        "-e", f"HIDE_OUTPUT={'1' if hide_output else ''}",
+    ]
+    if debug:
+        docker_cmd += ["-e", "GRADER_DEBUG=1"]
+    docker_cmd += [
+        "-v", f"{graders_dir}:/graders:ro",
+        image,
+        container_grader_path, str(seed),
+    ]
+
+    proc = subprocess.run(docker_cmd, capture_output=True, text=True)
+
+    if debug and proc.stderr:
+        print(proc.stderr, file=sys.stderr)
+
+    if proc.returncode != 0 or not proc.stdout.strip():
+        print(f"docker run exited {proc.returncode} with no valid output.", file=sys.stderr)
+        if proc.stderr:
+            print(proc.stderr, file=sys.stderr)
+        raise SystemExit(1)
+
+    result = json.loads(proc.stdout)
+
+    if json_output:
+        print(json.dumps(result, indent=2))
+    else:
+        _print_report(grader_path, submission_path, result)
+
+    if result["errors"] or not result["correct"]:
+        raise SystemExit(1)
+
+
+def _print_report(grader_path: Path, submission_path: Path, result: dict) -> None:
+    print(f"grader:     {grader_path}")
+    print(f"submission: {submission_path}")
+    print()
+
+    for error in result["errors"]:
+        print(f"ERROR: {error}")
+    if result["errors"]:
+        print()
+
+    for short_desc, long_desc, correct, expected, actual in result["tests"]:
+        status = "PASS" if correct else "FAIL"
+        print(f"[{status}] {short_desc}")
+        if long_desc:
+            print(f"       {long_desc}")
+        if not correct:
+            print("       expected:")
+            for line in expected.splitlines():
+                print(f"         {line}")
+            print("       actual:")
+            for line in actual.splitlines():
+                print(f"         {line}")
+
+    print()
+    print(f"score: {result['score']} ({'correct' if result['correct'] else 'incorrect'})")
+
+
+if __name__ == "__main__":
+    app()

--- a/grader_support/tools/grade-local
+++ b/grader_support/tools/grade-local
@@ -32,7 +32,7 @@ import cyclopts
 REPO_ROOT = Path.cwd()
 DEFAULT_GRADERS_DIR = REPO_ROOT / "graders"
 DEFAULT_IMAGE = f"{REPO_ROOT.name}:local"
-BUILD_ARGS = ["--build-arg", "GRADER_BASE_IMAGE=mitodl/xqueue-watcher-grader-base:latest"]
+BUILD_ARGS = ["--build-arg", "GRADER_BASE_IMAGE=ghcr.io/openedx/xqueue-watcher-grader-base:latest"]
 BUILD_CMD = " ".join(["docker", "build", *BUILD_ARGS, "-t", DEFAULT_IMAGE, "."])
 
 app = cyclopts.App(help=__doc__)

--- a/grader_support/tools/grade-local
+++ b/grader_support/tools/grade-local
@@ -32,10 +32,8 @@ import cyclopts
 REPO_ROOT = Path.cwd()
 DEFAULT_GRADERS_DIR = REPO_ROOT / "graders"
 DEFAULT_IMAGE = f"{REPO_ROOT.name}:local"
-BUILD_CMD = (
-    "docker build --build-arg GRADER_BASE_IMAGE=mitodl/xqueue-watcher-grader-base:latest "
-    f"-t {DEFAULT_IMAGE} ."
-)
+BUILD_ARGS = ["--build-arg", "GRADER_BASE_IMAGE=mitodl/xqueue-watcher-grader-base:latest"]
+BUILD_CMD = " ".join(["docker", "build", *BUILD_ARGS, "-t", DEFAULT_IMAGE, "."])
 
 app = cyclopts.App(help=__doc__)
 
@@ -65,6 +63,17 @@ def _image_exists(image: str) -> bool:
     return subprocess.run(
         ["docker", "image", "inspect", image], capture_output=True
     ).returncode == 0
+
+
+def _parse_json_output(stdout: str) -> dict:
+    """Scan backwards for the last non-empty line, matching how containergrader.py
+    parses container/pod output -- earlier lines may be stderr noise (deprecation
+    warnings, print statements) interleaved into stdout."""
+    for line in reversed(stdout.splitlines()):
+        stripped = line.strip()
+        if stripped:
+            return json.loads(stripped)
+    raise SystemExit("docker run produced no output.")
 
 
 @app.default
@@ -102,13 +111,17 @@ def run(
     json_output: Print the raw result dict as JSON instead of a formatted report.
     """
     grader_path = _resolve_grader_path(grader)
+    if not grader_path.is_file():
+        raise SystemExit(f"Grader file not found: {grader_path}")
     graders_dir = graders_dir.resolve()
     submission_path = (submission or grader_path.parent / "answer.py").resolve()
+    if not submission_path.is_file():
+        raise SystemExit(f"Submission file not found: {submission_path}")
     container_grader_path = _container_grader_path(grader_path, graders_dir)
 
     if not _image_exists(image):
         if build:
-            subprocess.run(["docker", "build", "-t", image, "."], cwd=REPO_ROOT, check=True)
+            subprocess.run(["docker", "build", *BUILD_ARGS, "-t", image, "."], cwd=REPO_ROOT, check=True)
         else:
             raise SystemExit(
                 f"Docker image {image!r} not found. Build it first:\n\n  {BUILD_CMD}\n\n"
@@ -142,7 +155,7 @@ def run(
             print(proc.stderr, file=sys.stderr)
         raise SystemExit(1)
 
-    result = json.loads(proc.stdout)
+    result = _parse_json_output(proc.stdout)
 
     if json_output:
         print(json.dumps(result, indent=2))


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
`entrypoint.py` grades the staff answer and the student submission in the same process, via two calls to `run_module.run()`. `run.py` imports the grader module by name with `__import__()`, and Python only executes a module's top-level code on the *first* import — the second call was silently reusing the cached module object, mutated leftovers and all.

Any grader with module-level mutable state leaked state from the first pass into the second:
- generators (e.g. an `inputOracle()` mocking `input()`) got exhausted by the first pass, so the second pass raised immediately
- a shared list/dict mutated in place by the first pass carried its final state into the second pass
- `rand` (bound via `from gradelib import *`) is a snapshot taken at import time, so it kept the *first* pass's already-advanced RNG instead of the freshly reseeded one `run.py` intends

This surfaced as a long list of course-team-reported "broken grader" issues in `graders-mit-600x` — see [`grader_issues.md`](https://github.com/mitodl/graders-mit-600x) for the original reports (exhausted `input()` mocks, results "feeding into themselves" between runs, wrong balances, and OOP/generator graders failing while structurally similar ones using stdlib `random.randint()` — immune to the leak, since `run.py` reseeds the *global* `random` module correctly on every call — kept "working"). Nearly every reported symptom traced back to this one gap.

The fix wraps each `run_module.run()` call in `graderutil.module_isolation()`, a context manager that already existed in this file's own `graderutil` import but was never actually used.

Also adds `grader_support/tools/grade-local`, a small CLI that runs a grader through `docker run` against a course repo's own grader image (the same engine `ContainerGrader` uses in production, not any legacy vendored grading engine), so course teams can reproduce and verify issues like this locally instead of only discovering them from production. Documented in `docs/course-teams.md` as the recommended fast path for the existing "Option 2: Run inside a grader container" section.

### Screenshots (if appropriate):
N/A

### How can this be tested?
1. `uv run pytest tests/` — all 129 existing tests still pass.
2. Manual repro (pre-fix): build a course image, e.g. `graders-mit-600x`, and grade a grader with module-level generator state (e.g. `finger_exercises/L3/numberGuessing`) against its own `answer.py`:
   ```bash
   docker run --rm -e SUBMISSION_CODE="$(cat graders/python3graders/finger_exercises/L3/numberGuessing/answer.py)" \
     graders-mit-600x:local /graders/python3graders/finger_exercises/L3/numberGuessing/grade_numberGuessing.py 42
   ```
   Pre-fix: scores 0.0, second test's actual output is empty (generator already exhausted by the first pass). Post-fix: scores 1.0, expected/actual match exactly.
3. Same test with `finger_exercises/L10/coordinate` (uses `gradelib.rand`, not stdlib `random`) shows mismatched random values pre-fix, matching values post-fix.
4. `grader_support/tools/grade-local unit-2/exercise-3/grader.py` against any course repo's own `answer.py` should score `1.0 (correct)`.

### Additional Context
Companion PRs land the `bin/grade-local` copy of this tool and confirm the fix in the two course repos that reported the original issues: `graders-mit-600x` and `graders-mit-686x`.